### PR TITLE
#25: 사용자 간 멘션 횟수 통계 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "moment-timezone": "^0.5.45",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
+                "react-graph-vis": "^1.0.7",
                 "react-typeahead": "^2.0.0-alpha.8",
                 "recharts": "^2.13.3",
                 "styled-components": "^6.1.12",
@@ -1910,6 +1911,19 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/@egjs/hammerjs": {
+            "version": "2.0.17",
+            "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+            "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@types/hammerjs": "^2.0.36"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
         "node_modules/@emotion/is-prop-valid": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
@@ -2825,6 +2839,13 @@
                 "@types/minimatch": "*",
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/hammerjs": {
+            "version": "2.0.46",
+            "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+            "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/@types/har-format": {
             "version": "1.2.16",
@@ -4732,6 +4753,16 @@
             "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
             "integrity": "sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==",
             "dev": true
+        },
+        "node_modules/component-emitter": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+            "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+            "license": "MIT",
+            "peer": true,
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/compressible": {
             "version": "2.0.18",
@@ -8485,6 +8516,13 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/keycharm": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/keycharm/-/keycharm-0.4.0.tgz",
+            "integrity": "sha512-TyQTtsabOVv3MeOpR92sIKk/br9wxS+zGj4BG7CR8YbK4jM3tyIBaF0zhzeBUMx36/Q/iQLOKKOT+3jOQtemRQ==",
+            "license": "(Apache-2.0 OR MIT)",
+            "peer": true
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -10342,6 +10380,29 @@
             "peerDependencies": {
                 "react": "^18.3.1"
             }
+        },
+        "node_modules/react-graph-vis": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/react-graph-vis/-/react-graph-vis-1.0.7.tgz",
+            "integrity": "sha512-FI35zlBMKU22JEvG1ukd1DDwW185y4YrDvHm6Bom9EGdA+UNMrZrIV/lyPIRWPcRkzbKaA1w1NvOYcRApD4KdQ==",
+            "license": "MIT",
+            "dependencies": {
+                "lodash": "^4.17.15",
+                "prop-types": "^15.5.10",
+                "uuid": "^2.0.1",
+                "vis-data": "^7.1.2",
+                "vis-network": "^9.0.0"
+            },
+            "peerDependencies": {
+                "react": "*"
+            }
+        },
+        "node_modules/react-graph-vis/node_modules/uuid": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+            "integrity": "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "license": "MIT"
         },
         "node_modules/react-is": {
             "version": "16.13.1",
@@ -12478,7 +12539,6 @@
             "version": "8.3.2",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
             "bin": {
                 "uuid": "dist/bin/uuid"
             }
@@ -12521,6 +12581,56 @@
                 "d3-shape": "^3.1.0",
                 "d3-time": "^3.0.0",
                 "d3-timer": "^3.0.1"
+            }
+        },
+        "node_modules/vis-data": {
+            "version": "7.1.9",
+            "resolved": "https://registry.npmjs.org/vis-data/-/vis-data-7.1.9.tgz",
+            "integrity": "sha512-COQsxlVrmcRIbZMMTYwD+C2bxYCFDNQ2EHESklPiInbD/Pk3JZ6qNL84Bp9wWjYjAzXfSlsNaFtRk+hO9yBPWA==",
+            "license": "(Apache-2.0 OR MIT)",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/visjs"
+            },
+            "peerDependencies": {
+                "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "vis-util": "^5.0.1"
+            }
+        },
+        "node_modules/vis-network": {
+            "version": "9.1.9",
+            "resolved": "https://registry.npmjs.org/vis-network/-/vis-network-9.1.9.tgz",
+            "integrity": "sha512-Ft+hLBVyiLstVYSb69Q1OIQeh3FeUxHJn0WdFcq+BFPqs+Vq1ibMi2sb//cxgq1CP7PH4yOXnHxEH/B2VzpZYA==",
+            "license": "(Apache-2.0 OR MIT)",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/visjs"
+            },
+            "peerDependencies": {
+                "@egjs/hammerjs": "^2.0.0",
+                "component-emitter": "^1.3.0",
+                "keycharm": "^0.2.0 || ^0.3.0 || ^0.4.0",
+                "uuid": "^3.4.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+                "vis-data": "^6.3.0 || ^7.0.0",
+                "vis-util": "^5.0.1"
+            }
+        },
+        "node_modules/vis-util": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/vis-util/-/vis-util-5.0.7.tgz",
+            "integrity": "sha512-E3L03G3+trvc/X4LXvBfih3YIHcKS2WrP0XTdZefr6W6Qi/2nNCqZfe4JFfJU6DcQLm6Gxqj2Pfl+02859oL5A==",
+            "license": "(Apache-2.0 OR MIT)",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/visjs"
+            },
+            "peerDependencies": {
+                "@egjs/hammerjs": "^2.0.0",
+                "component-emitter": "^1.3.0 || ^2.0.0"
             }
         },
         "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "moment-timezone": "^0.5.45",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-graph-vis": "^1.0.7",
         "react-typeahead": "^2.0.0-alpha.8",
         "recharts": "^2.13.3",
         "styled-components": "^6.1.12",

--- a/src/pages/Stat/StatView/AbstractStatView.jsx
+++ b/src/pages/Stat/StatView/AbstractStatView.jsx
@@ -74,6 +74,7 @@ const SeriesView = (series = [], first, show = {}) =>
  * @property {object} show
  * @property {Array<number>} userlist
  * @property {boolean} isUserlistForExclude
+ * @property {number} hubSize For graph view
  */
 
 const CriteriaPanel = styled.details.attrs(

--- a/src/pages/Stat/StatView/AbstractStatView.jsx
+++ b/src/pages/Stat/StatView/AbstractStatView.jsx
@@ -263,6 +263,7 @@ const Rechart = ({ $chartData = [], $chartOptions = {}, $criteria = {} }) => (
     <ResponsiveContainer
         width="100%"
         height="100%"
+        // TODO: refactor
         children={
             <ComposedChart data={$chartData}>
                 <CartesianGrid strokeDasharray="3 3" />

--- a/src/pages/Stat/StatView/AbstractStatView.jsx
+++ b/src/pages/Stat/StatView/AbstractStatView.jsx
@@ -75,6 +75,7 @@ const SeriesView = (series = [], first, show = {}) =>
  * @property {Array<number>} userlist
  * @property {boolean} isUserlistForExclude
  * @property {number} hubSize For graph view
+ * @property {boolean} isOpened
  */
 
 const CriteriaPanel = styled.details.attrs(
@@ -94,6 +95,9 @@ const CriteriaPanel = styled.details.attrs(
                 {children}
             </>
         ),
+        onToggle: ({ target }) => {
+            $setCriteria({ ...$criteria, isOpened: target.open });
+        },
     })
 )`
     margin-bottom: 1rem;
@@ -113,6 +117,7 @@ const Rechart = ({ $chartData = [], $chartOptions = {}, $criteria = {} }) => (
         width="100%"
         height="100%"
         // TODO: refactor
+        // TODO: fix height exceeding when criteria details is opened
         children={
             <ComposedChart data={$chartData}>
                 <CartesianGrid strokeDasharray="3 3" />

--- a/src/pages/Stat/StatView/AbstractStatView.jsx
+++ b/src/pages/Stat/StatView/AbstractStatView.jsx
@@ -3,7 +3,7 @@ import { CartesianGrid, Legend, Line, Area, ComposedChart, ResponsiveContainer, 
 import styled from 'styled-components';
 import { createEnum, makeId } from '../../../modules/util';
 import { Tokenizer } from 'react-typeahead';
-import { DateCriteria, SeriesCriteria, SortCriteria } from './Criteria';
+import { DateCriteria, SeriesCriteria, SortCriteria, UserCriteria } from './Criteria';
 
 /**
  * @enum {{Line, Area}} The type of series
@@ -91,45 +91,6 @@ const CriteriaPanel = styled.details.attrs(
             <>
                 <summary>표시 옵션</summary>
                 {children}
-                <fieldset>
-                    <legend>표시할 사용자</legend>
-                    <Tokenizer
-                        options={$userList.filter(({ userNo }) => $criteria.userlist.indexOf(userNo) === -1)}
-                        placeholder="사용자를 선택하세요."
-                        displayOption="name"
-                        filterOption="name"
-                        onTokenAdd={(token) => {
-                            let userlist = $criteria.userlist;
-                            userlist.push(token.userNo);
-                            $setCriteria({ ...$criteria, userlist });
-                        }}
-                        onTokenRemove={(token) => {
-                            let userlist = $criteria.userlist;
-                            let idx = userlist.findIndex((v) => v === token.userNo);
-                            if (idx > -1) userlist.splice(idx, 1);
-                            $setCriteria({ ...$criteria, userlist });
-                        }}
-                        showOptionsWhenEmpty={true}
-                    />
-                    <div>
-                        <input
-                            type="radio"
-                            id="criteria-user-bound"
-                            name="criteria-user"
-                            checked={!$criteria.isUserlistForExclude}
-                            onChange={(e) => $setCriteria({ ...$criteria, isUserlistForExclude: !e.target.checked })}
-                        />
-                        <label htmlFor="criteria-user-bound">선택한 사용자들만 표시</label>
-                        <input
-                            type="radio"
-                            id="criteria-user-exclude"
-                            name="criteria-user"
-                            checked={$criteria.isUserlistForExclude}
-                            onChange={(e) => $setCriteria({ ...$criteria, isUserlistForExclude: e.target.checked })}
-                        />
-                        <label htmlFor="criteria-user-exclude">선택한 사용자들을 제외하고 표시</label>
-                    </div>
-                </fieldset>
             </>
         ),
     })
@@ -140,59 +101,6 @@ const CriteriaPanel = styled.details.attrs(
 
     &[open] summary {
         margin-bottom: 1rem;
-    }
-
-    div.typeahead-tokenizer {
-        div.typeahead-token {
-            border: 1px solid black;
-            padding: 0.5em;
-            display: inline-block;
-
-            &:not(:first-child) {
-                border-left: none;
-            }
-
-            a.typeahead-token-close {
-                margin-left: 0.5em;
-                text-decoration: none;
-                color: gray;
-            }
-        }
-
-        div.typeahead {
-            margin-top: 0.5rem;
-
-            input {
-                width: 100%;
-            }
-
-            ul.typeahead-selector {
-                position: absolute;
-                border: 1px solid black;
-                list-style: none;
-                margin: 0;
-                padding: 0;
-                z-index: 1;
-                max-height: 15rem;
-                overflow-y: scroll;
-
-                li {
-                    padding: 1rem;
-                    border-bottom: 1px solid black;
-                    background: white;
-                    cursor: pointer;
-
-                    &:last-child {
-                        border-bottom: none;
-                    }
-
-                    a {
-                        text-decoration: none;
-                        color: black;
-                    }
-                }
-            }
-        }
     }
 `;
 
@@ -244,6 +152,12 @@ const DefaultCriteriaElements = ({ $chartOptions = {}, $criteria = {}, $setCrite
             $userList={$userList}
         />
         <SeriesCriteria
+            $chartOptions={$chartOptions}
+            $criteria={$criteria}
+            $setCriteria={$setCriteria}
+            $userList={$userList}
+        />
+        <UserCriteria
             $chartOptions={$chartOptions}
             $criteria={$criteria}
             $setCriteria={$setCriteria}

--- a/src/pages/Stat/StatView/AbstractStatView.jsx
+++ b/src/pages/Stat/StatView/AbstractStatView.jsx
@@ -3,6 +3,7 @@ import { CartesianGrid, Legend, Line, Area, ComposedChart, ResponsiveContainer, 
 import styled from 'styled-components';
 import { createEnum, makeId } from '../../../modules/util';
 import { Tokenizer } from 'react-typeahead';
+import { SortCriteria } from './Criteria';
 
 /**
  * @enum {{Line, Area}} The type of series
@@ -82,35 +83,19 @@ const CriteriaPanel = styled.details.attrs(
      * @param {Criteria} attrs.$criteria The criteria object that controls view
      * @param {React.Dispatch<React.SetStateAction<Criteria>>} attrs.$setCriteria The setter of criteria object
      * @param {Array<{ name: string, userNo: number }>} attrs.$userList List of users shown in the view
+     * @param {React.JSX.Element} attrs.children Criteria elements
      * @returns {import('styled-components').Attrs}
      */
-    ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [] }) => ({
+    ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [], children }) => ({
         children: (
             <>
                 <summary>표시 옵션</summary>
-                <div>
-                    <label htmlFor="criteria-sort">정렬 기준: </label>
-                    <select
-                        id="criteria-sort"
-                        value={$criteria.sort}
-                        onChange={(e) => $setCriteria({ ...$criteria, sort: e.target.value })}
-                    >
-                        <option value="name">이름</option>
-                        <option value="total-value">총합</option>
-                        {$chartOptions.series.map(({ name, key }, idx) => (
-                            <option key={`criteria-sort-${idx}`} value={key}>
-                                {name}
-                            </option>
-                        ))}
-                    </select>
-                    <input
-                        type="checkbox"
-                        id="criteria-reverse"
-                        checked={$criteria.reverse}
-                        onChange={(e) => $setCriteria({ ...$criteria, reverse: e.target.checked })}
-                    />
-                    <label htmlFor="criteria-reverse">역순</label>
-                </div>
+                <SortCriteria
+                    $chartOptions={$chartOptions}
+                    $criteria={$criteria}
+                    $setCriteria={$setCriteria}
+                    $userList={$userList}
+                />
                 <div>
                     기간:{' '}
                     <input

--- a/src/pages/Stat/StatView/AbstractStatView.jsx
+++ b/src/pages/Stat/StatView/AbstractStatView.jsx
@@ -3,7 +3,7 @@ import { CartesianGrid, Legend, Line, Area, ComposedChart, ResponsiveContainer, 
 import styled from 'styled-components';
 import { createEnum, makeId } from '../../../modules/util';
 import { Tokenizer } from 'react-typeahead';
-import { DateCriteria, SortCriteria } from './Criteria';
+import { DateCriteria, SeriesCriteria, SortCriteria } from './Criteria';
 
 /**
  * @enum {{Line, Area}} The type of series
@@ -91,24 +91,6 @@ const CriteriaPanel = styled.details.attrs(
             <>
                 <summary>표시 옵션</summary>
                 {children}
-                <div>
-                    표시할 항목:{' '}
-                    {$chartOptions.series.map(({ name, key }, idx) => (
-                        <Fragment key={`criteria-show-${key}`}>
-                            <input
-                                type="checkbox"
-                                id={`criteria-show-${key}`}
-                                checked={$criteria.show[key]}
-                                onChange={(e) => {
-                                    let show = $criteria.show;
-                                    show[key] = e.target.checked;
-                                    $setCriteria({ ...$criteria, show });
-                                }}
-                            />
-                            <label htmlFor={`criteria-show-${key}`}>{name}</label>{' '}
-                        </Fragment>
-                    ))}
-                </div>
                 <fieldset>
                     <legend>표시할 사용자</legend>
                     <Tokenizer
@@ -256,6 +238,12 @@ const DefaultCriteriaElements = ({ $chartOptions = {}, $criteria = {}, $setCrite
             $userList={$userList}
         />
         <DateCriteria
+            $chartOptions={$chartOptions}
+            $criteria={$criteria}
+            $setCriteria={$setCriteria}
+            $userList={$userList}
+        />
+        <SeriesCriteria
             $chartOptions={$chartOptions}
             $criteria={$criteria}
             $setCriteria={$setCriteria}

--- a/src/pages/Stat/StatView/Criteria.jsx
+++ b/src/pages/Stat/StatView/Criteria.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { styled } from 'styled-components';
+
+/**
+ * @callback CriteriaElement
+ * @param {{ $chartOptions: import('./AbstractStatView').ChartOptions, $criteria: import('./AbstractStatView').Criteria, $setCriteria: React.Dispatch<React.SetStateAction<import('./AbstractStatView').Criteria>>, $userList: Array<{ name: string, userNo: number }> }} attrs
+ * @returns {import('styled-components').Attrs}
+ */
+
+export const SortCriteria = styled.div.attrs(
+    /**
+     * @type CriteriaElement
+     */
+    ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [] }) => ({
+        children: (
+            <>
+                <label htmlFor="criteria-sort">정렬 기준: </label>
+                <select
+                    id="criteria-sort"
+                    value={$criteria.sort}
+                    onChange={(e) => $setCriteria({ ...$criteria, sort: e.target.value })}
+                >
+                    <option value="name">이름</option>
+                    <option value="total-value">총합</option>
+                    {$chartOptions.series.map(({ name, key }, idx) => (
+                        <option key={`criteria-sort-${idx}`} value={key}>
+                            {name}
+                        </option>
+                    ))}
+                </select>
+                <input
+                    type="checkbox"
+                    id="criteria-reverse"
+                    checked={$criteria.reverse}
+                    onChange={(e) => $setCriteria({ ...$criteria, reverse: e.target.checked })}
+                />
+                <label htmlFor="criteria-reverse">역순</label>
+            </>
+        ),
+    })
+)``;

--- a/src/pages/Stat/StatView/Criteria.jsx
+++ b/src/pages/Stat/StatView/Criteria.jsx
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { Tokenizer } from 'react-typeahead';
 import { styled } from 'styled-components';
 
 /**
@@ -106,3 +107,105 @@ export const SeriesCriteria = styled.div.attrs(
         ),
     })
 )``;
+
+export const UserCriteria = styled.fieldset.attrs(
+    /**
+     * @type CriteriaElement
+     */
+    ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [] }) => ({
+        children: (
+            <>
+                <legend>표시할 사용자</legend>
+                <Tokenizer
+                    options={$userList.filter(({ userNo }) => $criteria.userlist.indexOf(userNo) === -1)}
+                    placeholder="사용자를 선택하세요."
+                    displayOption="name"
+                    filterOption="name"
+                    onTokenAdd={(token) => {
+                        let userlist = $criteria.userlist;
+                        userlist.push(token.userNo);
+                        $setCriteria({ ...$criteria, userlist });
+                    }}
+                    onTokenRemove={(token) => {
+                        let userlist = $criteria.userlist;
+                        let idx = userlist.findIndex((v) => v === token.userNo);
+                        if (idx > -1) userlist.splice(idx, 1);
+                        $setCriteria({ ...$criteria, userlist });
+                    }}
+                    showOptionsWhenEmpty={true}
+                />
+                <div>
+                    <input
+                        type="radio"
+                        id="criteria-user-bound"
+                        name="criteria-user"
+                        checked={!$criteria.isUserlistForExclude}
+                        onChange={(e) => $setCriteria({ ...$criteria, isUserlistForExclude: !e.target.checked })}
+                    />
+                    <label htmlFor="criteria-user-bound">선택한 사용자들만 표시</label>
+                    <input
+                        type="radio"
+                        id="criteria-user-exclude"
+                        name="criteria-user"
+                        checked={$criteria.isUserlistForExclude}
+                        onChange={(e) => $setCriteria({ ...$criteria, isUserlistForExclude: e.target.checked })}
+                    />
+                    <label htmlFor="criteria-user-exclude">선택한 사용자들을 제외하고 표시</label>
+                </div>
+            </>
+        ),
+    })
+)`
+    div.typeahead-tokenizer {
+        div.typeahead-token {
+            border: 1px solid black;
+            padding: 0.5em;
+            display: inline-block;
+
+            &:not(:first-child) {
+                border-left: none;
+            }
+
+            a.typeahead-token-close {
+                margin-left: 0.5em;
+                text-decoration: none;
+                color: gray;
+            }
+        }
+
+        div.typeahead {
+            margin-top: 0.5rem;
+
+            input {
+                width: 100%;
+            }
+
+            ul.typeahead-selector {
+                position: absolute;
+                border: 1px solid black;
+                list-style: none;
+                margin: 0;
+                padding: 0;
+                z-index: 1;
+                max-height: 15rem;
+                overflow-y: scroll;
+
+                li {
+                    padding: 1rem;
+                    border-bottom: 1px solid black;
+                    background: white;
+                    cursor: pointer;
+
+                    &:last-child {
+                        border-bottom: none;
+                    }
+
+                    a {
+                        text-decoration: none;
+                        color: black;
+                    }
+                }
+            }
+        }
+    }
+`;

--- a/src/pages/Stat/StatView/Criteria.jsx
+++ b/src/pages/Stat/StatView/Criteria.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { styled } from 'styled-components';
 
 /**
@@ -74,6 +74,34 @@ export const DateCriteria = styled.div.attrs(
                     value={formatDate($criteria.until)}
                     onChange={(e) => $setCriteria({ ...$criteria, until: new Date(e.target.value).truncTime() })}
                 />
+            </>
+        ),
+    })
+)``;
+
+export const SeriesCriteria = styled.div.attrs(
+    /**
+     * @type CriteriaElement
+     */
+    ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [] }) => ({
+        children: (
+            <>
+                표시할 항목:{' '}
+                {$chartOptions.series.map(({ name, key }, idx) => (
+                    <Fragment key={`criteria-show-${key}`}>
+                        <input
+                            type="checkbox"
+                            id={`criteria-show-${key}`}
+                            checked={$criteria.show[key]}
+                            onChange={(e) => {
+                                let show = $criteria.show;
+                                show[key] = e.target.checked;
+                                $setCriteria({ ...$criteria, show });
+                            }}
+                        />
+                        <label htmlFor={`criteria-show-${key}`}>{name}</label>{' '}
+                    </Fragment>
+                ))}
             </>
         ),
     })

--- a/src/pages/Stat/StatView/Criteria.jsx
+++ b/src/pages/Stat/StatView/Criteria.jsx
@@ -39,3 +39,42 @@ export const SortCriteria = styled.div.attrs(
         ),
     })
 )``;
+
+// ref: https://velog.io/@rkio/Javascript-YYYY-MM-DD-%ED%98%95%ED%83%9C%EC%9D%98-%EB%82%A0%EC%A7%9C-%EC%A0%95%EB%B3%B4%EB%A5%BC-%EB%A7%8C%EB%93%A4%EC%96%B4%EB%B3%B4%EC%9E%90
+const formatDate = (date) =>
+    `${date.getFullYear()}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date
+        .getDate()
+        .toString()
+        .padStart(2, '0')}`;
+
+export const DateCriteria = styled.div.attrs(
+    /**
+     * @type CriteriaElement
+     */
+    ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [] }) => ({
+        children: (
+            <>
+                기간:{' '}
+                <input
+                    type="date"
+                    value={formatDate($criteria.since)}
+                    onChange={(e) => {
+                        let since = new Date(e.target.value).truncTime();
+                        $setCriteria({
+                            ...$criteria,
+                            since,
+                            until: new Date(Math.max(since, $criteria.until)).truncTime(),
+                        });
+                    }}
+                />{' '}
+                ~{' '}
+                <input
+                    type="date"
+                    min={formatDate($criteria.since)}
+                    value={formatDate($criteria.until)}
+                    onChange={(e) => $setCriteria({ ...$criteria, until: new Date(e.target.value).truncTime() })}
+                />
+            </>
+        ),
+    })
+)``;

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -149,19 +149,33 @@ export const PeerMentions = createStatView(
                 },
             };
 
-            let [resizeGraph, setResizeGraph] = useState(null);
+            let [network, setNetwork] = useState(null);
 
             useEffect(() => {
-                resizeGraph && resizeGraph();
+                if (!network) return;
+
+                const resizeGraph = () => {
+                    const container = network.view.body.container;
+
+                    network.setSize(0, 0);
+                    console.debug('[Resized] Graph container size', container.clientWidth, container.clientHeight);
+                    network.setSize(container.clientWidth, container.clientHeight);
+                    network.fit();
+                };
+                resizeGraph();
+
                 window.addEventListener('resize', resizeGraph);
-                return () => window.removeEventListener('resize', resizeGraph);
-            }, [graph, resizeGraph]);
+
+                return () => {
+                    window.removeEventListener('resize', resizeGraph);
+                };
+            }, [network]);
 
             return (
                 <>
                     <GraphStyle />
                     <Graph
-                        key={Date.now()}
+                        key={$criteria.hubSize}
                         graph={graph}
                         options={options}
                         events={events}
@@ -169,14 +183,9 @@ export const PeerMentions = createStatView(
                             const container = network.view.body.container;
                             console.debug('Graph container size', container.clientWidth, container.clientHeight);
 
-                            setResizeGraph(() => {
-                                network.setSize(0, 0);
-                                console.debug('Graph container size', container.clientWidth, container.clientHeight);
-                                network.setSize(container.clientWidth, container.clientHeight);
-                                network.fit();
-                            });
+                            setNetwork(network);
 
-                            console.debug($criteria.hubSize ?? 0);
+                            console.debug(`Hubsize = ${$criteria.hubSize ?? 0}`);
                         }}
                     />
                 </>
@@ -270,8 +279,6 @@ export const PeerMentions = createStatView(
             .map((user) => {
                 const entriesToOutside = [];
                 const entriesToInside = [];
-
-                console.log(user);
 
                 Object.entries(user.relationship).forEach((entry) => {
                     if (userIdsInsideMainstream.indexOf(entry[1].user_no) === -1) entriesToOutside.push(entry);

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -175,7 +175,7 @@ export const PeerMentions = createStatView(
                 <>
                     <GraphStyle />
                     <Graph
-                        key={$criteria.hubSize}
+                        key={`${$criteria.hubSize}_${$criteria.isOpened}`}
                         graph={graph}
                         options={options}
                         events={events}

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -127,6 +127,7 @@ export const PeerMentions = createStatView(
                             ? `${$criteria.hubSize ?? 0}명을 초과하는 사용자와 대화하는 사용자`
                             : `${item.name} (${item.user_no})`,
                     group: item.relationship.length,
+                    // TODO: set position to be more readable
                 })),
                 edges: $chartData.flatMap((from) =>
                     from.relationship.map((to) => ({
@@ -160,6 +161,7 @@ export const PeerMentions = createStatView(
                 physics: {
                     enabled: false,
                 },
+                // TODO: set colors of each groups constantly
             };
 
             const events = {

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -1,5 +1,16 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { createStatView, SeriesType } from './AbstractStatView';
+import Graph from 'react-graph-vis';
+import { createGlobalStyle } from 'styled-components';
+
+const GraphStyle = createGlobalStyle`
+    div.vis-tooltip {
+        position: absolute;
+        color: black;
+        border: 1px solid black;
+        background-color: white;
+    }
+`;
 
 /**
  * @type {import('./AbstractStatView').StatView}
@@ -27,7 +38,69 @@ export const PeerMentions = createStatView(
                 stackId: 1,
             },
         ],
-        ChartElement: ({ $chartData, $chartOptions, $criteria }) => <></>,
+        ChartElement: ({ $chartData, $chartOptions, $criteria }) => {
+            const graph = {
+                nodes: [
+                    { id: 1, label: 'Node 1', title: 'node 1 tootip text' },
+                    { id: 2, label: 'Node 2', title: 'node 2 tootip text' },
+                    { id: 3, label: 'Node 3', title: 'node 3 tootip text' },
+                    { id: 4, label: 'Node 4', title: 'node 4 tootip text' },
+                    { id: 5, label: 'Node 5', title: 'node 5 tootip text' },
+                ],
+                edges: [
+                    { from: 1, to: 2, value: 1, title: 'absolute' },
+                    { from: 1, to: 3, value: 3 },
+                    { from: 2, to: 4, value: 5 },
+                    { from: 2, to: 5, value: 7 },
+                ],
+            };
+
+            const options = {
+                layout: {
+                    hierarchical: true,
+                },
+                edges: {
+                    color: '#000000',
+                },
+            };
+
+            const events = {
+                select: function (event) {
+                    var { nodes, edges } = event;
+                    console.debug('On select node', event);
+                },
+            };
+
+            let resizeGraph;
+
+            useEffect(() => {
+                return () => window.removeEventListener('resize', resizeGraph);
+            });
+
+            return (
+                <>
+                    <GraphStyle />
+                    <Graph
+                        graph={graph}
+                        options={options}
+                        events={events}
+                        getNetwork={(network) => {
+                            const container = network.view.body.container;
+                            console.debug('Graph container size', container.clientWidth, container.clientHeight);
+
+                            resizeGraph = () => {
+                                network.setSize(0, 0);
+                                console.debug('Graph container size', container.clientWidth, container.clientHeight);
+                                network.setSize(container.clientWidth, container.clientHeight);
+                                network.fit();
+                            };
+
+                            window.addEventListener('resize', resizeGraph);
+                        }}
+                    />
+                </>
+            );
+        },
     },
     (data, criteria) =>
         Object.values(

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { createStatView, SeriesType } from './AbstractStatView';
 import Graph from 'react-graph-vis';
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, styled } from 'styled-components';
+import { DateCriteria, SeriesCriteria, UserCriteria } from './Criteria';
 
 const GraphStyle = createGlobalStyle`
     div.vis-tooltip {
@@ -27,6 +28,32 @@ const createRelationship = (acc, from, to) =>
         comments: 0,
         mentions: 0,
     });
+
+export const HubsizeCriteria = styled.fieldset.attrs(
+    /**
+     * @type {import('./Criteria').CriteriaElement}
+     */ ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [] }) => ({
+        children: (
+            <>
+                <legend>관계도 옵션</legend>
+                주로 대화하는 사용자 범위:{' '}
+                <input
+                    type="number"
+                    min={0}
+                    max={$userList.length}
+                    value={$criteria.hubSize ?? 0}
+                    onChange={(e) => {
+                        $setCriteria({
+                            ...$criteria,
+                            hubSize: Number(e.target.value),
+                        });
+                    }}
+                />
+                명 이하의 사용자와 대화하는 사용자를 제외한 나머지
+            </>
+        ),
+    })
+)``;
 
 /**
  * @type {import('./AbstractStatView').StatView}
@@ -54,6 +81,34 @@ export const PeerMentions = createStatView(
                 stackId: 1,
             },
         ],
+        CriteriaElements: ({ $chartOptions = {}, $criteria = {}, $setCriteria = () => {}, $userList = [] }) => (
+            <>
+                <DateCriteria
+                    $chartOptions={$chartOptions}
+                    $criteria={$criteria}
+                    $setCriteria={$setCriteria}
+                    $userList={$userList}
+                />
+                <SeriesCriteria
+                    $chartOptions={$chartOptions}
+                    $criteria={$criteria}
+                    $setCriteria={$setCriteria}
+                    $userList={$userList}
+                />
+                <UserCriteria
+                    $chartOptions={$chartOptions}
+                    $criteria={$criteria}
+                    $setCriteria={$setCriteria}
+                    $userList={$userList}
+                />
+                <HubsizeCriteria
+                    $chartOptions={$chartOptions}
+                    $criteria={$criteria}
+                    $setCriteria={$setCriteria}
+                    $userList={$userList}
+                />
+            </>
+        ),
         ChartElement: ({ $chartData, $chartOptions, $criteria }) => {
             const graph = {
                 nodes: $chartData.map((item) => ({
@@ -121,7 +176,9 @@ export const PeerMentions = createStatView(
                                 network.fit();
                             });
 
-                            network.clustering.clusterByHubsize({
+                            console.debug($criteria.hubSize ?? 0);
+
+                            network.clustering.clusterByHubsize(($criteria.hubSize ?? 0) * 2, {
                                 clusterNodeProperties: { label: '주로 대화하는 사용자', x: 0, y: 0 },
                             });
                         }}

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { createStatView, SeriesType } from './AbstractStatView';
+
+/**
+ * @type {import('./AbstractStatView').StatView}
+ */
+export const PeerMentions = createStatView(
+    '사용자 간 멘션 횟수',
+    '사용자끼리 댓글을 달거나 멘션한 횟수를 나타낸 관계도입니다',
+    {
+        extendXAxis: true,
+        series: [
+            {
+                name: '댓글 횟수',
+                type: SeriesType.Line,
+                key: 'comments',
+                stroke: '#ff7300',
+                fill: '#ff7300',
+                stackId: 1,
+            },
+            {
+                name: '멘션 횟수',
+                type: SeriesType.Line,
+                key: 'mentions',
+                stroke: '#8884d8',
+                fill: '#8884d8',
+                stackId: 1,
+            },
+        ],
+        ChartElement: ({ $chartData, $chartOptions, $criteria }) => <></>,
+    },
+    (data, criteria) =>
+        Object.values(
+            data.posts.reduce((acc, post) => {
+                if (
+                    !new Date(post.created_at).isBetween(criteria.since, criteria.until) ||
+                    (criteria.userlist.length > 0 &&
+                        // If both conditions are all true or false (i.e. true and true, false and false)
+                        !!(criteria.isUserlistForExclude ^ (criteria.userlist.indexOf(post.author.user_no) === -1)))
+                )
+                    return acc;
+
+                if (!acc[post.author.user_no])
+                    acc[post.author.user_no] = { name: post.author.name, reads: 0, comments: 0, emotions: 0, posts: 0 };
+
+                acc[post.author.user_no].posts++;
+                acc[post.author.user_no].reads += post.read_count;
+                acc[post.author.user_no].comments += post.comment_count;
+                acc[post.author.user_no].emotions += post.emotion_count;
+
+                return acc;
+            }, {})
+        ).sort(
+            !criteria.sort || criteria.sort === 'name'
+                ? (a, b) => a.name.localeCompare(b.name) * (criteria.reverse ? -1 : 1)
+                : criteria.sort === 'total-value'
+                ? (a, b) =>
+                      (b.reads + b.comments + b.emotions - (a.reads + a.comments + a.emotions)) *
+                      (criteria.reverse ? -1 : 1)
+                : (a, b) => (b[criteria.sort] - a[criteria.sort]) * (criteria.reverse ? -1 : 1)
+        )
+);

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -60,8 +60,7 @@ export const PeerMentions = createStatView(
                     id: item.user_no,
                     label: item.name,
                     title: `${item.name} (${item.user_no})`,
-                    group: item.relationship.reduce((acc, cur) => acc + cur.comments + cur.mentions, 0),
-                    connections: item.relationship.length,
+                    group: item.relationship.length,
                 })),
                 edges: $chartData.flatMap((from) =>
                     from.relationship.map((to) => ({
@@ -116,12 +115,14 @@ export const PeerMentions = createStatView(
                             console.debug('Graph container size', container.clientWidth, container.clientHeight);
 
                             setResizeGraph(() => {
-                                network.setData(graph);
                                 network.setSize(0, 0);
                                 console.debug('Graph container size', container.clientWidth, container.clientHeight);
                                 network.setSize(container.clientWidth, container.clientHeight);
                                 network.fit();
-                                network.clustering.clusterByHubsize();
+                            });
+
+                            network.clustering.clusterByHubsize({
+                                clusterNodeProperties: { label: '주로 대화하는 사용자', x: 0, y: 0 },
                             });
                         }}
                     />

--- a/src/pages/Stat/StatView/PeerMentions.jsx
+++ b/src/pages/Stat/StatView/PeerMentions.jsx
@@ -114,7 +114,10 @@ export const PeerMentions = createStatView(
                 nodes: $chartData.map((item) => ({
                     id: item.user_no,
                     label: item.name,
-                    title: `${item.name} (${item.user_no})`,
+                    title:
+                        item.user_no === 'mainstream'
+                            ? `${$criteria.hubSize ?? 0}명을 초과하는 사용자와 대화하는 사용자`
+                            : `${item.name} (${item.user_no})`,
                     group: item.relationship.length,
                 })),
                 edges: $chartData.flatMap((from) =>

--- a/src/pages/Stat/StatView/index.jsx
+++ b/src/pages/Stat/StatView/index.jsx
@@ -5,6 +5,7 @@ import { faBars, faXmark } from '@fortawesome/free-solid-svg-icons';
 import { ArticlePerUser } from './ArticlePerUser';
 import { TotalReactsPerUser } from './TotalReactsPerUser';
 import { AvgReactsPerUser } from './AvgReactsPerUser';
+import { PeerMentions } from './PeerMentions';
 
 const statTypeWidth = 320;
 
@@ -126,7 +127,7 @@ const Item = styled.li.attrs({})`
     cursor: pointer;
 `;
 
-const statViews = [ArticlePerUser, TotalReactsPerUser, AvgReactsPerUser];
+const statViews = [ArticlePerUser, TotalReactsPerUser, AvgReactsPerUser, PeerMentions];
 
 export const StatView = ({ data }) => {
     const [showNav, setShowNav] = useState(false);


### PR DESCRIPTION
- resolves #25
  - 통계 화면 추가
  - 데이터로부터 댓글 및 멘션 횟수 통계 추출 및 그래프로 구현
  - Criteria 변경 시 반응 속도를 올리기 위해, criteria 변경 시 그래프가 자동으로 refresh되게 설정
  - 반응 속도를 올리기 위해, "주로 대화하는 사용자" 클러스터를 직접 작성하도록 함
  - 역방향 간선이 있는 경우 두 간선 모두를 커브 형태로 표시하여, 두 간선이 겹쳐지지 않도록 함
- Rechart 이외의 다른 화면을 사용할 수 있도록 구현 변경
  - `react-graph-vis`를 이용한 그래프 구현
- 표시 옵션의 각 항목을 별개의 요소로 분리하고, 각 화면별로 표시 옵션을 선택할 수 있도록 구현 변경
  - "주로 대화하는 사용자" 클러스터의 크기를 지정할 수 있도록 표시 옵션 커스터마이징
- 화면 크기가 바뀔때뿐 아니라, 표시 옵션 패널이 열리거나 닫힐 때에도 resize가 수행되도록 변경