### PR TITLE
#43: 밴드 페이지 변경 이후 확장 프로그램이 동작하지 않는 문제 해결

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "OCTrollFinder4Band",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "A chrome extension to find trolls in OC community on Band",
     "license": "MIT",
     "repository": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,7 @@
     },
     "content_scripts": [
         {
-            "matches": ["*://band.us/*"],
+            "matches": ["*://www.band.us/*", "*://band.us/*"],
             "js": ["contentScript.bundle.js"],
             "css": ["content.styles.css"]
         }
@@ -22,14 +22,14 @@
     "web_accessible_resources": [
         {
             "resources": ["content.styles.css", "icon-128.png", "icon-34.png"],
-            "matches": []
+            "matches": ["*://www.band.us/*", "*://band.us/*"]
         },
         {
             "resources": ["injectScript.bundle.js"],
-            "matches": ["*://band.us/*"]
+            "matches": ["*://www.band.us/*", "*://band.us/*"]
         }
     ],
     "permissions": ["tabs", "storage", "unlimitedStorage", "alarms"],
-    "host_permissions": ["*://band.us/*"],
+    "host_permissions": ["*://www.band.us/*", "*://band.us/*"],
     "default_locale": "ko"
 }


### PR DESCRIPTION
- resolves #43 
  - 밴드 측에서 주로 사용하는 URL을 변경함
  - manifest에 등록된 URL matching과 불일치하여 content script 로드가 불가능하여 문제가 발생하였음
  - manifest를 변경하여 문제 해결함