### PR TITLE
CVE-2025-12816 및 CVE-2025-66030 대응: node-forge 업데이트

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
                 "fs-extra": "^11.3.0",
                 "html-loader": "^4.2.0",
                 "html-webpack-plugin": "^5.6.3",
+                "node-forge": "^1.3.3",
                 "prettier": "^2.8.8",
                 "react-refresh": "^0.14.2",
                 "react-refresh-typescript": "^2.0.7",
@@ -9064,9 +9065,9 @@
             "optional": true
         },
         "node_modules/node-forge": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
+            "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
             "dev": true,
             "license": "(BSD-3-Clause OR GPL-2.0)",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
         "fs-extra": "^11.3.0",
         "html-loader": "^4.2.0",
         "html-webpack-plugin": "^5.6.3",
+        "node-forge": "^1.3.3",
         "prettier": "^2.8.8",
         "react-refresh": "^0.14.2",
         "react-refresh-typescript": "^2.0.7",


### PR DESCRIPTION
- [CVE-2025-12816](https://github.com/Quirax/OCTrollFinder4Band/security/dependabot/17) 및 [CVE-2025-66030](https://github.com/Quirax/OCTrollFinder4Band/security/dependabot/18)에 대응하여, `node-forge`를 `1.3.3`으로 업데이트
- 참고: Dev-dependency이므로 별도의 재배포는 불필요함